### PR TITLE
fix(utils/pubsub): add options on subscription

### DIFF
--- a/utils/pubsub.js
+++ b/utils/pubsub.js
@@ -58,7 +58,7 @@ class ExtendedPubSub extends PubSub {
       throw new Error('topicOrName must be string or topic instance.');
     })();
 
-    return topic.subscription(name);
+    return topic.subscription(name, options);
   }
 }
 


### PR DESCRIPTION
Subscription miss `options` for setting flowControl.
Here are ref: https://github.com/googleapis/nodejs-pubsub/blob/master/samples/subscriptions.js#L114