### PR TITLE
fix: skip ackid length is zero and setting isProgress counter

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -95,6 +95,7 @@ class Worker extends EventEmitter {
 
           const doneCallback = async () => {
             if (isDoneOrFailed || ackIds.length === 0) {
+              inProgress = inProgress > 0 ? inProgress - 1 : 0;
               return;
             }
 


### PR DESCRIPTION
The bulk worker will stack when `isProgress` is not reduce.